### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,5 +1,8 @@
 name: Run Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/mesolimbo/cvgenai/security/code-scanning/1](https://github.com/mesolimbo/cvgenai/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Since the workflow only requires read access to repository contents, the `permissions` block should specify `contents: read`. This change ensures that the `GITHUB_TOKEN` used by the workflow has the minimum required privileges.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
