### PR TITLE
Fix generator selection when specific flags used

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ run.sh --content my-other-resume.toml
   - **`document.py`**: Abstractions for resume and cover letter documents
   - **`config.py`**: TOML configuration loader
   - **`services/`**: File, HTML, PDF and customization services
-  - **`templating/`**: Template rendering helpers
+  - **`templating/`**: Jinja template rendering helper
 - **`templates/`**: Contains HTML templates and CSS styles
   - `cover_letter_template.html`: Template for cover letters
   - `resume_page1_template.html`: Template for resume page 1

--- a/src/cvgenai/factory.py
+++ b/src/cvgenai/factory.py
@@ -163,8 +163,9 @@ class Factory:
         any_generator_specified = False
         for generator in all_generators:
             arg_name = generator.get('arg')
-            if arg_name and hasattr(self.args, arg_name.replace('-', '_')):
-                arg_value = getattr(self.args, arg_name.replace('-', '_'))
+            if arg_name:
+                arg_key = arg_name.replace('-', '_')
+                arg_value = self.args.get(arg_key)
                 if arg_value:
                     generators_to_run.append(generator['name'])
                     any_generator_specified = True

--- a/tests/cvgenai/test_factory.py
+++ b/tests/cvgenai/test_factory.py
@@ -259,9 +259,37 @@ class TestFactory:
 
         # Get generators to run
         generators = factory.get_generators_to_run()
-        
+
         # Verify that all enabled generators are included
         assert set(generators) == {'resume', 'cover-letter'}
+
+    @staticmethod
+    @patch('cvgenai.factory.Factory._create_instance_from_path', return_value=MagicMock())
+    @patch('cvgenai.factory.Factory._parse_args', return_value={'resume': True, 'cover_letter': False})
+    def test_get_generators_to_run_resume_only(_, __):
+        """When only the resume flag is set only that generator should run."""
+        from cvgenai.factory import Factory
+        factory = Factory()
+        factory.app_config = {
+            'documents': {
+                'generators': [
+                    {
+                        'name': 'resume',
+                        'enabled': True,
+                        'arg': 'resume',
+                    },
+                    {
+                        'name': 'cover_letter',
+                        'enabled': True,
+                        'arg': 'cover-letter',
+                    },
+                ]
+            }
+        }
+
+        generators = factory.get_generators_to_run()
+
+        assert generators == ['resume']
 
     @staticmethod
     @patch('cvgenai.factory.Factory._create_instance_from_path', return_value=MagicMock())


### PR DESCRIPTION
## Summary
- ensure factory checks CLI args correctly
- add regression test for selecting only one generator

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f269883a8832cbc6e001b490878b7