### PR TITLE
Fix CLI generator flag logic; add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Determine version
+        id: get_version
+        run: |
+          ver=$(python - <<'PY'
+          import tomllib, pathlib
+          data = tomllib.loads(pathlib.Path('pyproject.toml').read_text())
+          print(data['project']['version'])
+          PY
+          )
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+
+      - name: Show release details
+        if: github.event_name == 'pull_request'
+        run: echo "Would create release v${{ steps.get_version.outputs.version }}"
+
+      - name: Create tag
+        if: github.event_name != 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git tag "v${{ steps.get_version.outputs.version }}"
+          git push origin "v${{ steps.get_version.outputs.version }}"
+
+      - name: Create GitHub release
+        if: github.event_name != 'pull_request'
+        uses: actions/create-release@v1
+        with:
+          tag_name: "v${{ steps.get_version.outputs.version }}"
+          release_name: "v${{ steps.get_version.outputs.version }}"

--- a/src/cvgenai/factory.py
+++ b/src/cvgenai/factory.py
@@ -163,8 +163,9 @@ class Factory:
         any_generator_specified = False
         for generator in all_generators:
             arg_name = generator.get('arg')
-            if arg_name and hasattr(self.args, arg_name.replace('-', '_')):
-                arg_value = getattr(self.args, arg_name.replace('-', '_'))
+            if arg_name:
+                arg_key = arg_name.replace('-', '_')
+                arg_value = self.args.get(arg_key)
                 if arg_value:
                     generators_to_run.append(generator['name'])
                     any_generator_specified = True

--- a/tests/cvgenai/test_factory.py
+++ b/tests/cvgenai/test_factory.py
@@ -259,9 +259,37 @@ class TestFactory:
 
         # Get generators to run
         generators = factory.get_generators_to_run()
-        
+
         # Verify that all enabled generators are included
         assert set(generators) == {'resume', 'cover-letter'}
+
+    @staticmethod
+    @patch('cvgenai.factory.Factory._create_instance_from_path', return_value=MagicMock())
+    @patch('cvgenai.factory.Factory._parse_args', return_value={'resume': True, 'cover_letter': False})
+    def test_get_generators_to_run_resume_only(_, __):
+        """When only the resume flag is set only that generator should run."""
+        from cvgenai.factory import Factory
+        factory = Factory()
+        factory.app_config = {
+            'documents': {
+                'generators': [
+                    {
+                        'name': 'resume',
+                        'enabled': True,
+                        'arg': 'resume',
+                    },
+                    {
+                        'name': 'cover_letter',
+                        'enabled': True,
+                        'arg': 'cover-letter',
+                    },
+                ]
+            }
+        }
+
+        generators = factory.get_generators_to_run()
+
+        assert generators == ['resume']
 
     @staticmethod
     @patch('cvgenai.factory.Factory._create_instance_from_path', return_value=MagicMock())


### PR DESCRIPTION
## Summary
- ensure factory checks CLI args correctly
- add regression test for selecting only one generator
- add GitHub Actions workflow that tags a release on main

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f269883a8832cbc6e001b490878b7