### PR TITLE
Fix CI release logic

### DIFF
--- a/.github/scripts/check_tag_exists.py
+++ b/.github/scripts/check_tag_exists.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+
+def main():
+    """Check if a git tag exists and print 'true' or 'false'."""
+    if len(sys.argv) != 2:
+        print("Usage: check_tag_exists.py <tag>", file=sys.stderr)
+        sys.exit(1)
+    tag = sys.argv[1]
+    result = subprocess.run([
+        "git",
+        "rev-parse",
+        "--quiet",
+        "--verify",
+        f"refs/tags/{tag}"
+    ])
+    if result.returncode == 0:
+        print("true")
+    else:
+        print("false")
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,18 @@ jobs:
           ver=$(python .github/scripts/get_version.py)
           echo "version=$ver" >> "$GITHUB_OUTPUT"
 
+      - name: Check if tag exists
+        id: check_tag
+        run: |
+          exists=$(python .github/scripts/check_tag_exists.py "v${{ steps.get_version.outputs.version }}")
+          echo "exists=$exists" >> "$GITHUB_OUTPUT"
+
       - name: Show release details
         run: |
           echo "Version to release: ${{ steps.get_version.outputs.version }}"
 
       - name: Create tag
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && steps.check_tag.outputs.exists == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -86,7 +92,7 @@ jobs:
           git push origin "v${{ steps.get_version.outputs.version }}"
 
       - name: Create GitHub release
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && steps.check_tag.outputs.exists == 'false'
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add docstring to `check_tag_exists.py`
- CI uses `check_tag_exists.py` to skip release steps when tag already exists

## Testing
- `pipenv install --dev`
- `./test.sh -t`


------
https://chatgpt.com/codex/tasks/task_e_6855fcfcd3a8832c96d82d59a34df97a